### PR TITLE
Ignore last incomplete line if required

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,19 @@
+const NEWLINES_REGEX = /(\n|\r\n)/;
 
-const parse = (jsonString) => {
+function lastIndexOfRegex(str, regex) {
+  const match = str.match(regex);
+  return match ? str.lastIndexOf(match[match.length - 1]) : -1;
+}
+
+const parse = (jsonString, ignoreLastIncompleteLine = false) => {
   const type = typeof jsonString;
   if (type !== 'string') throw new Error(`Input have to be string but got ${type}`);
-
-  const jsonRows = jsonString.split(/\n|\n\r/).filter(Boolean);
+  let jsonData = jsonString;
+  if (ignoreLastIncompleteLine) {
+    jsonData = jsonData.substr(0, lastIndexOfRegex(jsonString, NEWLINES_REGEX));
+  }
+  const jsonRows = jsonData.split(/\n|\n\r/).filter(Boolean);
   return jsonRows.map(jsonStringRow => JSON.parse(jsonStringRow));
 };
-
 
 module.exports = parse;

--- a/test.js
+++ b/test.js
@@ -92,4 +92,15 @@ describe('Parse Ndjson', () => {
       done();
     }
   });
+
+  it('should ignore last incomplete line if required', (done) => {
+    const jsonObject = { some: 'thing' };
+    const stringifiedJsonObject = JSON.stringify(jsonObject);
+    ['\n', '\r\n'].forEach((delimiter) => {
+      const parsed = ndjsonParser(`${stringifiedJsonObject}${delimiter}${stringifiedJsonObject.substr(0, 5)}`, true);
+      expect(parsed.length).toEqual(1);
+      expect(parsed[0]).toEqual(jsonObject);
+    });
+    done();
+  });
 });


### PR DESCRIPTION
For example, when partial data received from S3 file (first n bytes) and parser should ignore last incomplete line.